### PR TITLE
Fix Time Format Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var getTimeData = function (timezone) {
     var date = new Date();
     if (timezone == "local") {
         return {
-            time: date.toLocaleTimeString(),
+            time: date.toLocaleTimeString('en-US', { hour12: false }),
             date: date.toLocaleDateString(),
             datetime: date.toLocaleString(),
             UTCEpochMS: date.getTime(),


### PR DESCRIPTION
In local timezone setting, actualTime is in 12h format as default, which doesn't correspond with internal format.
Therefore, set 24h format as defined option.